### PR TITLE
Explosion adjustments

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,12 +1,10 @@
-[gd_resource type="AudioBusLayout" format=3]
+[gd_resource type="AudioBusLayout" load_steps=2 format=3 uid="uid://cy4v5dl85j1wv"]
+
+[sub_resource type="AudioEffectHardLimiter" id="AudioEffectHardLimiter_j3pel"]
+resource_name = "HardLimiter"
+ceiling_db = -14.0
 
 [resource]
-bus/0/name = &"Master"
-bus/0/solo = false
-bus/0/mute = false
-bus/0/bypass_fx = false
-bus/0/volume_db = 0.0
-bus/0/send = &""
 bus/1/name = &"Music"
 bus/1/solo = false
 bus/1/mute = false
@@ -19,6 +17,8 @@ bus/2/mute = false
 bus/2/bypass_fx = false
 bus/2/volume_db = 0.0
 bus/2/send = &"Master"
+bus/2/effect/0/effect = SubResource("AudioEffectHardLimiter_j3pel")
+bus/2/effect/0/enabled = true
 bus/3/name = &"Dialog"
 bus/3/solo = false
 bus/3/mute = false


### PR DESCRIPTION
_Attempts to fix the incredibly loud explosion sounds when multiple enemies explode at the same time_

**Changes made:**
**Added a randomized delay between 0-0.65 seconds before each explosion goes off.** This reduces the amount of sounds playing at the _exact_ same time, effectively reducing how much these sounds overlap. It also looks cooler when a bunch of explosions go off at once, in my opinion. **One downside** to this approach is that an unlucky chatter might feel an extra 0.65 seconds of delay before their explosion triggers. You can adjust the time range to your liking, or choose to not implement this feature entirely.

**Added a hard limiter effect to the "SFX" audio bus to cap sound effect volume.** This effectively caps how loud sound effects in this audio bus can be. This value is currently set at -14dB. You can adjust this setting in Godot by clicking on the Audio tab at the bottom of the screen, clicking on the "HardLimiter" effect in the "SFX" bus, and then tweaking the "Ceiling dB" value that appears on the right side of the window. **One downside** to the current implementation is that this applies to _all sounds in the "SFX" bus._ Some sounds unrelated to explosions may be quieter than before. You might consider moving explosions to their own audio bus. This also doesn't fix the root cause of the issue: every single explosion plays its own sound at the same time, causing the sounds to overlap.

**A true fix for this issue** in my opinion would be for each explosion sound that plays to stop all other explosion sounds that are currently playing, effectively cutting them off and preventing them from overlapping the first place. I don't know how to do this in Godot.

If you have any changes you want made before merging, let me know and I will made revisions.