### PR TITLE
Improve action feed clarity for ticket spawning system

### DIFF
--- a/systems/core/ticket_spawn_manager.gd
+++ b/systems/core/ticket_spawn_manager.gd
@@ -129,14 +129,14 @@ func handle_join_command(username: String) -> bool:
 	_rebuild_ticket_pool()
 	
 	chatter_joined.emit(username)
-	print("🎫 %s joined the session as %s" % [username, monster_type])
+	print("🎫 %s joined the ticket pool" % username)
 	
 	# Notify in action feed
 	if GameController.instance:
 		var action_feed = GameController.instance.get_action_feed()
 		if action_feed:
 			action_feed.add_message(
-				"⚔️ %s joined the battle!" % username,
+				"⚔️ %s joined the fight!" % username,
 				Color.CYAN
 			)
 	
@@ -217,6 +217,18 @@ func _spawn_random_monster() -> bool:
 	# Apply upgrades if needed
 	if ChatterEntityManager.instance:
 		_apply_upgrades_to_entity(enemy_id, username)
+	
+	# Notify action feed of successful spawn
+	if GameController.instance:
+		var action_feed = GameController.instance.get_action_feed()
+		if action_feed:
+			var monster_emoji = {"twitch_rat": "🐀", "succubus": "😈", "woodland_joe": "🌲"}.get(monster_type, "👾")
+			var concurrent_count = alive_monsters[username].size()
+			var count_text = " (#" + str(concurrent_count) + ")" if concurrent_count > 1 else ""
+			action_feed.add_message(
+				"⚔️ %s has been chosen for battle!" % username,
+				Color.LIME_GREEN
+			)
 	
 	entity_spawned.emit(username, enemy_id)
 	

--- a/systems/core/ticket_spawn_manager.gd
+++ b/systems/core/ticket_spawn_manager.gd
@@ -226,7 +226,7 @@ func _spawn_random_monster() -> bool:
 			var concurrent_count = alive_monsters[username].size()
 			var count_text = " (#" + str(concurrent_count) + ")" if concurrent_count > 1 else ""
 			action_feed.add_message(
-				"⚔️ %s has been chosen for battle%s!" % [username, count_text],
+				"%s ⚔️ %s has been chosen for battle%s!" % [monster_emoji, username, count_text],
 				Color.LIME_GREEN
 			)
 	

--- a/systems/core/ticket_spawn_manager.gd
+++ b/systems/core/ticket_spawn_manager.gd
@@ -226,7 +226,7 @@ func _spawn_random_monster() -> bool:
 			var concurrent_count = alive_monsters[username].size()
 			var count_text = " (#" + str(concurrent_count) + ")" if concurrent_count > 1 else ""
 			action_feed.add_message(
-				"⚔️ %s has been chosen for battle!" % username,
+				"⚔️ %s has been chosen for battle%s!" % [username, count_text],
 				Color.LIME_GREEN
 			)
 	

--- a/ui/pause_menu.gd
+++ b/ui/pause_menu.gd
@@ -99,6 +99,7 @@ func _ready():
 	var debug_btn = _create_menu_button("🔧 DEBUG PANEL", Color(1, 0.3, 1))
 	debug_btn.pressed.connect(_on_debug_pressed)
 	button_container.add_child(debug_btn)
+
 	
 	# Spacer
 	main_container.add_child(Control.new())
@@ -560,6 +561,7 @@ func _on_debug_pressed():
 	
 	# Toggle visibility
 	debug_panel_window.visible = !debug_panel_window.visible
+
 
 func show_menu():
 	visible = true


### PR DESCRIPTION
Small change to the action feed to reflect ticket spawning system, Chatters will now know when they actually spawn.
(Also I closed this earlier because claude fucked it and I had to manually fix it, so much for paid LLM's being better) 

- Update join message: 'joined the battle' → 'joined the fight'
- Add spawn notification when chatters get drawn from ticket pool
- Show concurrent monster count for multiple spawns.
- Fix misleading console print message about monster type
- Update spawn message to 'has been chosen for battle'

Changes to ui/pause_menu.gd were related to debugger I implemented to test the action feed. 
<img width="377" height="215" alt="image" src="https://github.com/user-attachments/assets/f251985d-8c27-43b5-a2ad-ed7c1b3b77b2" />
