### PR TITLE
Greatly increased wall thickness

### DIFF
--- a/game_controller.gd
+++ b/game_controller.gd
@@ -269,10 +269,12 @@ func _setup_world():
 	# Bosses are now spawned via voting system, not automatically
 
 func _create_arena_walls(arena_size: float):
-	var wall_thickness = 50.0
+	# 500 pixels thick should stop ANY entity
+	var wall_thickness = 500.0
 	var half_size = arena_size / 2.0
 	
 	# Wall positions: [position, size, name]
+	# Positioned so the inner edge is exactly at the arena boundary
 	var walls = [
 		[Vector2(-half_size - wall_thickness/2.0, 0), Vector2(wall_thickness, arena_size + wall_thickness*2.0), "WestWall"],
 		[Vector2(half_size + wall_thickness/2.0, 0), Vector2(wall_thickness, arena_size + wall_thickness*2.0), "EastWall"],
@@ -285,8 +287,8 @@ func _create_arena_walls(arena_size: float):
 		var wall_body = StaticBody2D.new()
 		wall_body.name = wall_data[2]
 		wall_body.position = wall_data[0]
-		wall_body.collision_layer = 1
-		wall_body.collision_mask = 0
+		wall_body.collision_layer = 1  # Wall collision layer
+		wall_body.collision_mask = 0   # Walls don't need to detect anything
 		wall_body.process_mode = Node.PROCESS_MODE_PAUSABLE
 		add_child(wall_body)
 		


### PR DESCRIPTION
From: https://github.com/VIBER-CODERS-ANON/AI_SLOP_SURVIVORS/issues/23

Made walls far thicker while retaining their positions, prevents player from dashing through and should prevent enemies from phasing through if there are tons of them in one location

A small bit of the background is still visible on purpose for future background art if that is planned

Before:
<img width="814" height="993" alt="480154694-3b052d1d-78d9-4efa-945f-a6cb05102ed0" src="https://github.com/user-attachments/assets/497b2663-c7a1-4828-a8cd-5578b0b01db7" />

After
<img width="854" height="1000" alt="480155868-ce1e1343-c0c6-4453-a0d6-04f72e25f554" src="https://github.com/user-attachments/assets/fa7c78d1-51c5-48e8-b825-1bc3facc321e" />
