### PR TITLE
Fixed boon text layout

### DIFF
--- a/ui/boon_selection.gd
+++ b/ui/boon_selection.gd
@@ -84,6 +84,7 @@ func _create_boon_card() -> Control:
 	content.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	content.add_theme_constant_override("separation", 10)
 	panel.add_child(content)
+	content.position.y += 10
 	
 	# Rarity label
 	var rarity_label = Label.new()


### PR DESCRIPTION
Moved VBoxContainer down by 10 pixels on boon selection to give enough room for border of selection box, now more centred

Before:
<img width="996" height="322" alt="image" src="https://github.com/user-attachments/assets/fa290c99-099d-4c7d-ac2f-3596d393cfb7" />

After:
<img width="949" height="303" alt="image" src="https://github.com/user-attachments/assets/887d77e8-a476-44e6-aafb-3dc55aa83f67" />
