### PR TITLE
fix(ui): remove horizontal scrollbar in pause menu; widen container

### DIFF
--- a/ui/pause_menu.gd
+++ b/ui/pause_menu.gd
@@ -53,8 +53,10 @@ func _ready():
 	# Create main container with scroll
 	var scroll_container = ScrollContainer.new()
 	scroll_container.set_anchors_and_offsets_preset(Control.PRESET_CENTER)
-	scroll_container.position = Vector2(-180, -280)  # Center the container
-	scroll_container.custom_minimum_size = Vector2(360, 560)
+	scroll_container.position = Vector2(-260, -320)  # Center the wider container
+	scroll_container.custom_minimum_size = Vector2(520, 640)
+	scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	scroll_container.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
 	scroll_container.follow_focus = true
 	add_child(scroll_container)
 	


### PR DESCRIPTION
Problem

- The pause menu appeared inside a horizontally scrollable panel, showing a scrollbar and causing the button borders to visually clash with the right edge.

Root Cause

- The ScrollContainer used default horizontal scrolling (Auto) and the content’s min width exceeded the 360px container width, enabling the horizontal bar.

What’s Changed

- Disable horizontal scrolling and keep vertical auto:

  - horizontal_scroll_mode = Disabled
  - vertical_scroll_mode = Auto

- Widen content to avoid clipping and improve spacing:
  - custom_minimum_size: 520x640

- Re-center the container for the wider layout

Result

- No horizontal scrollbar; vertical scroll only when needed. Buttons and title render cleanly without overlapping the right edge.

Testing

- Open the game, press ESC to open the pause menu.
- Verify no horizontal scrollbar appears at common resolutions (720p, 1080p, 1440p, 4K).
- Confirm vertical scrolling still works when content exceeds the viewport height.

Risk

- Low. UI-only change to the pause menu container properties.

Files

- ui/pause_menu.gd
