### PR TITLE
Implemented a stagger on explosion and balance audio output

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,12 +1,10 @@
-[gd_resource type="AudioBusLayout" format=3]
+[gd_resource type="AudioBusLayout" load_steps=2 format=3 uid="uid://4mqf4dw2n8r"]
+
+[sub_resource type="AudioEffectHardLimiter" id="AudioEffectHardLimiter_SFX"]
+resource_name = "SFXLimiter"
+ceiling_db = -14.0
 
 [resource]
-bus/0/name = &"Master"
-bus/0/solo = false
-bus/0/mute = false
-bus/0/bypass_fx = false
-bus/0/volume_db = 0.0
-bus/0/send = &""
 bus/1/name = &"Music"
 bus/1/solo = false
 bus/1/mute = false
@@ -19,6 +17,8 @@ bus/2/mute = false
 bus/2/bypass_fx = false
 bus/2/volume_db = 0.0
 bus/2/send = &"Master"
+bus/2/effect/0/effect = SubResource("AudioEffectHardLimiter_SFX")
+bus/2/effect/0/enabled = true
 bus/3/name = &"Dialog"
 bus/3/solo = false
 bus/3/mute = false


### PR DESCRIPTION
Taken the suggestions from https://github.com/VIBER-CODERS-ANON/AI_SLOP_SURVIVORS/pull/17 and changed some things slightly:

- Staggers simultaneous explosions: each explosion waits up to 0.4s before its telegraph starts, reducing warning spam stacking.
- Warning beep plays quieter (−18 dB) when telegraph begins.
- Impact plays at 0 dB for a clear hit without being harsh.
- Prevents clipping/distortion: adds a HardLimiter on the SFX bus (ceiling −14 dB) so many overlapping sounds don’t overdrive the mix