### PR TITLE
fix(enemy): remove lingering corpses in collision pool

### DIFF
--- a/systems/bridge/enemy_body.gd
+++ b/systems/bridge/enemy_body.gd
@@ -23,6 +23,11 @@ func take_damage(damage_amount: float, attacker: Node = null, _weapon_tags: Arra
 	var mgr = _get_manager()
 	if enemy_id < 0 or mgr == null:
 		return
+	
+	# Critical fix: Check if enemy is still alive before processing damage
+	if enemy_id >= mgr.alive_flags.size() or mgr.alive_flags[enemy_id] == 0:
+		return  # Enemy is already dead, ignore damage
+	
 	var killer_name: String = ""
 	if attacker:
 		if attacker.has_meta("chatter_username"):

--- a/systems/core/enemy_manager.gd
+++ b/systems/core/enemy_manager.gd
@@ -555,13 +555,14 @@ func despawn_enemy(id: int):
 	var live_index = live_enemy_ids.find(id)
 	if live_index >= 0 and live_index < live_enemy_bodies.size():
 		var body = live_enemy_bodies[live_index]
-		live_enemy_ids.remove_at(live_index)
+		# Mark the slot as invalid instead of removing to preserve array alignment
+		live_enemy_ids[live_index] = -1  # Invalid ID marker
 		body.set_physics_process(false)
 		body.visible = false
 		# Fully disable collisions when released
 		body.collision_layer = 0
 		body.collision_mask = 0
-		body.set_meta("enemy_id", null)
+		body.set_meta("enemy_id", -1)  # Mark as invalid instead of null
 
 func damage_enemy(id: int, damage: float, killer_name: String = "", death_cause: String = ""):
 	if id < 0 or id >= alive_flags.size() or alive_flags[id] == 0:
@@ -868,6 +869,10 @@ func _update_live_bodies_positions_only():
 			# Hide invalid entries quickly; full rebuild will happen on next interval
 			live_enemy_bodies[i].set_physics_process(false)
 			live_enemy_bodies[i].visible = false
+			# Fully disable collisions for invalid entries
+			live_enemy_bodies[i].collision_layer = 0
+			live_enemy_bodies[i].collision_mask = 0
+			live_enemy_bodies[i].set_meta("enemy_id", -1)
 
 func _update_multimesh_transforms():
 	if multi_mesh_instance == null:


### PR DESCRIPTION
- EnemyManager.despawn_enemy: mark live slot as -1 instead of remove_at; immediately disable body (physics, visibility, layers/mask) and clear enemy_id
- EnemyManager._update_live_bodies_positions_only: fully disable bodies for invalid/dead entries (set layers/mask=0, enemy_id=-1)
- EnemyBody.take_damage: ignore damage if entity is dead (alive_flags check)

Result: dead enemies no longer collide or award points; invisible “corpse” bodies are reclaimed cleanly.